### PR TITLE
Fix version detection for 1.17 & 1.16.4

### DIFF
--- a/src/main/java/me/hyfe/simplespigot/version/ServerVersion.java
+++ b/src/main/java/me/hyfe/simplespigot/version/ServerVersion.java
@@ -24,8 +24,8 @@ public enum ServerVersion {
     MC1_16_R1(1161),
     MC1_16_R2(1162),
     MC1_16_R3(1163),
-    MC_1_16_R4(1164),
-    MC_1_17_R1(1170);
+    MC1_16_R4(1164),
+    MC1_17_R1(1170);
 
     private static ServerVersion serverVersion;
     private final int versionId;


### PR DESCRIPTION
This fixes ServerVersion not properly detecting 1.16.4 and 1.17/1.17.1.